### PR TITLE
Fixed style and script attributes handled as array

### DIFF
--- a/engines/common/nucleus/particles/assets.html.twig
+++ b/engines/common/nucleus/particles/assets.html.twig
@@ -1,22 +1,40 @@
 {% spaceless %}
 {% if (particle.enabled) %}
     {% for css in particle.css %}
+        {% set params = {} %}
+        {% if css.extra %}
+            {% for attributes in css.extra %}
+                {% for key, value in attributes %}
+                    {% set params = params|default({})|merge({(key): value}) %}
+                {% endfor %}
+            {% endfor %}
+        {% endif %}
+
         {% if css.location %}
-            {% do gantry.document.addStyle(css.extra|default({})|merge({href: css.location}), css.priority) %}
+            {% do gantry.document.addStyle(params|default({})|merge({href: css.location}), css.priority) %}
         {% endif %}
 
         {% if css.inline %}
-            {% do gantry.document.addInlineStyle(css.extra|default({})|merge({content: css.inline}), css.priority) %}
+            {% do gantry.document.addInlineStyle(params|default({})|merge({content: css.inline}), css.priority) %}
         {% endif %}
     {% endfor %}
 
     {% for script in particle.javascript %}
+        {% set params = {} %}
+        {% if script.extra %}
+            {% for attributes in script.extra %}
+                {% for key, value in attributes %}
+                    {% set params = params|default({})|merge({(key): value}) %}
+                {% endfor %}
+            {% endfor %}
+        {% endif %}
+
         {% if script.location %}
-            {% do gantry.document.addScript(script.extra|default({})|merge({src: script.location}), script.priority, script.in_footer == true ? 'footer' : 'head') %}
+            {% do gantry.document.addScript(params|default({})|merge({src: script.location}), script.priority, script.in_footer == true ? 'footer' : 'head') %}
         {% endif %}
 
         {% if script.inline %}
-            {% do gantry.document.addInlineScript(script.extra|default({})|merge({content: script.inline}), script.priority, script.in_footer == true ? 'footer' : 'head') %}
+            {% do gantry.document.addInlineScript(params|default({})|merge({content: script.inline}), script.priority, script.in_footer == true ? 'footer' : 'head') %}
         {% endif %}
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
Before this commit the parameters you add in  `Page Settings -> Asset Params ` are outputed as nummeric array.

Example: 
```html
<!-- wrong handling of attributes -->
<link href="print.css" rel="stylesheet" 0="{&quot;media&quot;:&quot;print&quot;}" />

<!-- attributes missing completely -->
<script type="text/javascript" src="responsive_tables.js"></script>
```

After this fix: 
```html
<!-- nearly all attributes are accepted -->
<link href="print.css" rel="stylesheet" media="print" />

<!-- some attributes are accepted -->
<script type="text/javascript" src="responsive_tables.js" async></script>
```

The [addScript](https://github.com/gantry/gantry5/blob/2758c7d4bc321153f52b6157a831b4d6ea2dacb8/src/classes/Gantry/Component/Content/Block/HtmlBlock.php#L286-L289) function however only accepts some basic Atributes (async, defer, ...) this issue is not adressed by this pull request.